### PR TITLE
replace hardcoded `Zi`

### DIFF
--- a/src/VueGAPI/GoogleAuthService.js
+++ b/src/VueGAPI/GoogleAuthService.js
@@ -99,7 +99,7 @@ export default class GoogleAuthService {
 
   _setSession (response) {
     const profile = this.authInstance.currentUser.get().getBasicProfile()
-    const authResult = response.Zi
+    const authResult = this.authInstance.currentUser.get().getAuthResponse(true)
     this._setStorage(authResult, profile)
     this.authenticated = true
   }


### PR DESCRIPTION
Recently sometimes I noticed that auth result can't be retrieved from `response.Zi`, rather it will be `response.uc`. not sure if it's gapi update or not. But I found this workaround which is more official according to https://stackoverflow.com/questions/44772200/google-sign-in-for-websites-how-to-get-token