### PR TITLE
Rejects error when loading auth client fails

### DIFF
--- a/src/VueGAPI/index.js
+++ b/src/VueGAPI/index.js
@@ -31,6 +31,7 @@ export default {
                   console.error(
                     'Failed to initialize gapi: %s (status=%s, code=%s)', error.message, error.status, error.code, err)
                 }
+                reject(err)
               })
           })
         } else {


### PR DESCRIPTION
I noticed that when the gapi plugin is installed, the promise does not reject when loading the auth client. This makes it hard to react on this error from another application using this package (like mine). I have added the one line to VueGAPI `index.js` for this. 

I followed the contribution guide, and if I need to write a test for this, could anyone guide me on where to start? There are no tests for install the GAPI yet. Running tests with jest still pass.